### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 
 **This repository is under construction.**
 
-This repository is designed as an example modeling Hub that follows the infrastructure guidelines laid out by the [Consortium of Infectious Disease Modeling Hubs](https://github.com/hubverse-org/). Additional details are provided in [the examples given in hubDocs](https://hubverse.io/en/latest/user-guide/intro-data-formats.html#running-examples).  
+This repository is designed as an example modeling Hub that follows the infrastructure guidelines laid out by the [Consortium of Infectious Disease Modeling Hubs](https://github.com/hubverse-org/). Additional details are provided in [the examples given in hubDocs](https://docs.hubverse.io/en/latest/user-guide/intro-data-formats.html#running-examples).  
 
 The example model outputs provided here are adapted from forecasts submitted to the US COVID-19 Forecast Hub but have been modified to provide examples of nowcasts. They should be viewed only as illustrations of the data formats, not as realistic examples of nowcasts and forecasts. In particular, scores calculated by comparing the model outputs to the target data will not give a meaningful measure of predictive skill.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is designed as an example modeling Hub that follows the
 infrastructure guidelines laid out by the [Consortium of Infectious
 Disease Modeling Hubs](https://github.com/hubverse-org/). Additional
 details are provided in [the examples given in
-hubDocs](https://hubverse.io/en/latest/user-guide/intro-data-formats.html#running-examples).
+hubDocs](https://docs.hubverse.io/en/latest/user-guide/intro-data-formats.html#running-examples).
 
 The example model outputs provided here are adapted from forecasts
 submitted to the US COVID-19 Forecast Hub but have been modified to


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.